### PR TITLE
chore: add monorepo linting, formatting, CI, and contribution standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run build
+
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+      - run: pip install -r requirements.txt
+      - run: ruff check app tests
+      - run: black --check app tests
+      - run: mypy app tests
+      - run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
+          cache-dependency-path: frontend/package.json
+      - run: npm install
       - run: npm run lint
       - run: npm run format:check
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ frontend/.next
 backend/.venv
 backend/__pycache__
 backend/.pytest_cache
+backend/.mypy_cache
+backend/.ruff_cache
+
+# Tooling
+.pre-commit-cache
 
 # OS
 .DS_Store
+
+__pycache__/
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--line-length=100]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        files: ^frontend/|\.(md|yml|yaml|json)$
+        additional_dependencies:
+          - prettier@3.5.3
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.22.0
+    hooks:
+      - id: eslint
+        files: ^frontend/.*\.(js|jsx|ts|tsx)$
+        additional_dependencies:
+          - eslint@9.22.0
+          - eslint-config-next@15.2.4
+          - @typescript-eslint/eslint-plugin@8.26.1
+          - @typescript-eslint/parser@8.26.1

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+frontend/.next
+frontend/node_modules
+backend/.venv

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for contributing to this monorepo.
+
+## Branching model
+
+- Branch from `main` using a feature branch:
+  - `feature/<short-description>`
+  - `fix/<short-description>`
+  - `chore/<short-description>`
+- Keep branches focused on a single change.
+
+## Commit messages
+
+Use Conventional Commits where possible:
+
+- `feat: add portfolio endpoint`
+- `fix: handle missing ticker in service`
+- `chore: update lint tooling`
+- `docs: clarify local setup`
+
+Format:
+
+```text
+<type>(optional-scope): short imperative summary
+```
+
+## Development standards
+
+### Coding standards
+
+- Prefer clear, small, composable functions.
+- Keep behavior changes separate from tooling/docs updates when possible.
+- Add or update tests with code changes that affect logic.
+
+### Naming conventions
+
+- **TypeScript/React**: components in `PascalCase`, variables/functions in `camelCase`, constants in `UPPER_SNAKE_CASE`.
+- **Python**: modules/functions/variables in `snake_case`, classes in `PascalCase`, constants in `UPPER_SNAKE_CASE`.
+
+### Error handling conventions
+
+- **Frontend**: surface user-friendly error messages and preserve server-provided details when available.
+- **Backend**: raise domain/service errors with actionable messages; convert to stable API error responses in the FastAPI layer.
+
+## Run checks locally
+
+From repo root:
+
+```bash
+make format
+make lint
+make typecheck
+make test
+make check
+```
+
+You can also run workspace-specific checks:
+
+```bash
+cd frontend && npm run lint && npm run format:check
+cd backend && ruff check app tests && black --check app tests && mypy app tests && pytest
+```
+
+## Pull request checklist
+
+Before opening a PR:
+
+- [ ] Rebased/merged latest `main`.
+- [ ] `make check` passes locally.
+- [ ] Added/updated tests for behavior changes.
+- [ ] Updated docs (README/CONTRIBUTING) if workflows changed.
+- [ ] Included screenshots for UI changes.
+- [ ] PR description clearly states what changed and why.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: format lint test typecheck check frontend-install backend-install
+
+frontend-install:
+	cd frontend && npm install
+
+backend-install:
+	cd backend && pip install -r requirements.txt
+
+format:
+	cd frontend && npm run format
+	cd backend && black app tests && ruff check app tests --fix
+
+lint:
+	cd frontend && npm run lint
+	cd frontend && npm run format:check
+	cd backend && ruff check app tests
+	cd backend && black --check app tests
+
+typecheck:
+	cd backend && mypy app tests
+
+test:
+	cd backend && pytest
+
+check: lint typecheck test

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ A full-stack monorepo with:
 │   │   ├── main.py
 │   │   ├── models.py
 │   │   └── service.py
+│   ├── pyproject.toml
 │   ├── requirements.txt
 │   └── tests
 │       └── test_api.py
 ├── docker-compose.yml
 ├── frontend
-│   ├── .env.example
+│   ├── .eslintrc.json
 │   ├── app
 │   │   ├── globals.css
 │   │   ├── layout.tsx
@@ -38,7 +39,12 @@ A full-stack monorepo with:
 │   ├── postcss.config.mjs
 │   ├── tailwind.config.ts
 │   └── tsconfig.json
-├── .gitignore
+├── .editorconfig
+├── .pre-commit-config.yaml
+├── .prettierignore
+├── .prettierrc.json
+├── CONTRIBUTING.md
+├── Makefile
 └── README.md
 ```
 
@@ -93,6 +99,58 @@ This starts:
 - frontend: `http://localhost:3000`
 - backend: `http://localhost:8000`
 
+## Development Standards
+
+### Tooling
+
+- **Frontend linting**: ESLint with `next/core-web-vitals`, `next/typescript`, and `@typescript-eslint/recommended`.
+- **Frontend formatting**: Prettier.
+- **Backend linting/import sorting**: Ruff.
+- **Backend formatting**: Black (`line-length = 100`).
+- **Backend type checking**: MyPy (strict-ish settings).
+
+### Repo-wide commands
+
+Run from repository root:
+
+```bash
+make format
+make lint
+make typecheck
+make test
+make check
+```
+
+### Frontend commands
+
+```bash
+cd frontend
+npm run lint
+npm run format
+npm run format:check
+npm run build
+```
+
+### Backend commands
+
+```bash
+cd backend
+ruff check app tests
+black --check app tests
+mypy app tests
+pytest
+```
+
+### Pre-commit (optional but recommended)
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
+Configured hooks run Ruff, Black, Prettier, and ESLint.
+
 ## Notes
 
 - Supported ranges: `1m`, `3m`, `6m`, `1y`, `5y`, `max`
@@ -100,10 +158,3 @@ This starts:
 - Backend cache: in-memory TTL (60 seconds)
 - Dates are returned as timezone-safe `YYYY-MM-DD`
 - Missing yfinance fields are returned as `null`
-
-## Run tests
-
-```bash
-cd backend
-pytest
-```

--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -12,7 +12,7 @@ class CacheEntry:
 
 
 class TTLCache:
-    def __init__(self, ttl_seconds: int = 60):
+    def __init__(self, ttl_seconds: int = 60) -> None:
         self.ttl_seconds = ttl_seconds
         self._store: dict[str, CacheEntry] = {}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,8 @@ from .service import ServiceError, StockService
 
 app = FastAPI(title='Stock Dashboard API')
 service = StockService(cache_ttl_seconds=60)
+TICKER_QUERY = Query(...)
+RANGE_QUERY = Query(...)
 
 app.add_middleware(
     CORSMiddleware,
@@ -26,7 +28,7 @@ def health() -> dict[str, str]:
 
 
 @app.get('/api/prices', response_model=PricesResponse, responses={400: {'model': APIError}, 502: {'model': APIError}})
-def prices(ticker: str = Query(...), range: RangeOption = Query(...)) -> PricesResponse | JSONResponse:
+def prices(ticker: str = TICKER_QUERY, range: RangeOption = RANGE_QUERY) -> PricesResponse | JSONResponse:
     try:
         params = QueryParams(ticker=ticker)
     except ValidationError as exc:
@@ -46,7 +48,7 @@ def prices(ticker: str = Query(...), range: RangeOption = Query(...)) -> PricesR
 
 
 @app.get('/api/metrics', response_model=MetricsResponse, responses={400: {'model': APIError}, 502: {'model': APIError}})
-def metrics(ticker: str = Query(...)) -> MetricsResponse | JSONResponse:
+def metrics(ticker: str = TICKER_QUERY) -> MetricsResponse | JSONResponse:
     try:
         params = QueryParams(ticker=ticker)
     except ValidationError as exc:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,60 +8,70 @@ from pydantic import ValidationError
 from .models import APIError, MetricsResponse, PricesResponse, QueryParams, RangeOption
 from .service import ServiceError, StockService
 
-app = FastAPI(title='Stock Dashboard API')
+app = FastAPI(title="Stock Dashboard API")
 service = StockService(cache_ttl_seconds=60)
 TICKER_QUERY = Query(...)
 RANGE_QUERY = Query(...)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=['http://localhost:3000', 'http://127.0.0.1:3000'],
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
     allow_credentials=True,
-    allow_methods=['*'],
-    allow_headers=['*'],
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 
-@app.get('/health')
+@app.get("/health")
 def health() -> dict[str, str]:
-    return {'status': 'ok'}
+    return {"status": "ok"}
 
 
-@app.get('/api/prices', response_model=PricesResponse, responses={400: {'model': APIError}, 502: {'model': APIError}})
-def prices(ticker: str = TICKER_QUERY, range: RangeOption = RANGE_QUERY) -> PricesResponse | JSONResponse:
+@app.get(
+    "/api/prices",
+    response_model=PricesResponse,
+    responses={400: {"model": APIError}, 502: {"model": APIError}},
+)
+def prices(
+    ticker: str = TICKER_QUERY, range: RangeOption = RANGE_QUERY
+) -> PricesResponse | JSONResponse:
     try:
         params = QueryParams(ticker=ticker)
     except ValidationError as exc:
         return JSONResponse(
             status_code=400,
-            content={'error': 'Invalid ticker', 'details': str(exc.errors()[0]['msg'])},
+            content={"error": "Invalid ticker", "details": str(exc.errors()[0]["msg"])},
         )
 
     try:
         return service.get_prices(params.ticker, range)
     except ServiceError as exc:
-        status_code = 400 if 'not found' in exc.message.lower() else 502
+        status_code = 400 if "not found" in exc.message.lower() else 502
         return JSONResponse(
             status_code=status_code,
-            content={'error': exc.message, 'details': exc.details},
+            content={"error": exc.message, "details": exc.details},
         )
 
 
-@app.get('/api/metrics', response_model=MetricsResponse, responses={400: {'model': APIError}, 502: {'model': APIError}})
+@app.get(
+    "/api/metrics",
+    response_model=MetricsResponse,
+    responses={400: {"model": APIError}, 502: {"model": APIError}},
+)
 def metrics(ticker: str = TICKER_QUERY) -> MetricsResponse | JSONResponse:
     try:
         params = QueryParams(ticker=ticker)
     except ValidationError as exc:
         return JSONResponse(
             status_code=400,
-            content={'error': 'Invalid ticker', 'details': str(exc.errors()[0]['msg'])},
+            content={"error": "Invalid ticker", "details": str(exc.errors()[0]["msg"])},
         )
 
     try:
         return service.get_metrics(params.ticker)
     except ServiceError as exc:
-        status_code = 400 if 'not found' in exc.message.lower() else 502
+        status_code = 400 if "not found" in exc.message.lower() else 502
         return JSONResponse(
             status_code=status_code,
-            content={'error': exc.message, 'details': exc.details},
+            content={"error": exc.message, "details": exc.details},
         )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-RangeOption = Literal['1m', '3m', '6m', '1y', '5y', 'max']
+RangeOption = Literal["1m", "3m", "6m", "1y", "5y", "max"]
 
 
 class PricePoint(BaseModel):
@@ -38,13 +38,13 @@ class APIError(BaseModel):
     details: str | None = None
 
 
-TICKER_REGEX = r'^[A-Za-z0-9.-]{1,10}$'
+TICKER_REGEX = r"^[A-Za-z0-9.-]{1,10}$"
 
 
 class QueryParams(BaseModel):
     ticker: str = Field(pattern=TICKER_REGEX)
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def normalize_ticker(cls, value: str) -> str:
         return value.upper()

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import cast
 from datetime import date
+from typing import cast
 
 import pandas as pd
 import yfinance as yf

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -10,12 +10,12 @@ from .cache import TTLCache
 from .models import MetricsResponse, PricePoint, PricesResponse, RangeOption
 
 PERIOD_MAP: dict[RangeOption, str] = {
-    '1m': '1mo',
-    '3m': '3mo',
-    '6m': '6mo',
-    '1y': '1y',
-    '5y': '5y',
-    'max': 'max',
+    "1m": "1mo",
+    "3m": "3mo",
+    "6m": "6mo",
+    "1y": "1y",
+    "5y": "5y",
+    "max": "max",
 }
 
 
@@ -34,7 +34,7 @@ class StockService:
         return yf.Ticker(symbol)
 
     def get_prices(self, ticker: str, range_option: RangeOption) -> PricesResponse:
-        cache_key = f'prices:{ticker}:{range_option}'
+        cache_key = f"prices:{ticker}:{range_option}"
         cached = self.cache.get(cache_key)
         if cached is not None:
             return cached
@@ -42,15 +42,15 @@ class StockService:
         period = PERIOD_MAP[range_option]
         try:
             ticker_obj = self._ticker(ticker)
-            history = ticker_obj.history(period=period, interval='1d', auto_adjust=False)
+            history = ticker_obj.history(period=period, interval="1d", auto_adjust=False)
         except Exception as exc:  # noqa: BLE001
-            raise ServiceError('Failed to fetch historical prices', str(exc)) from exc
+            raise ServiceError("Failed to fetch historical prices", str(exc)) from exc
 
-        if history.empty or 'Close' not in history:
-            raise ServiceError('Ticker not found or no historical data available', ticker)
+        if history.empty or "Close" not in history:
+            raise ServiceError("Ticker not found or no historical data available", ticker)
 
         points: list[PricePoint] = []
-        close_series = history['Close'].dropna()
+        close_series = history["Close"].dropna()
 
         for timestamp, close in close_series.items():
             if isinstance(timestamp, pd.Timestamp):
@@ -59,7 +59,7 @@ class StockService:
                 point_date = pd.to_datetime(timestamp).date()
             points.append(PricePoint(date=point_date.isoformat(), close=float(close)))
 
-        currency = self._safe_info_value(ticker_obj.info, 'currency')
+        currency = self._safe_info_value(ticker_obj.info, "currency")
 
         response = PricesResponse(
             ticker=ticker,
@@ -71,7 +71,7 @@ class StockService:
         return response
 
     def get_metrics(self, ticker: str) -> MetricsResponse:
-        cache_key = f'metrics:{ticker}'
+        cache_key = f"metrics:{ticker}"
         cached = self.cache.get(cache_key)
         if cached is not None:
             return cached
@@ -80,23 +80,23 @@ class StockService:
             ticker_obj = self._ticker(ticker)
             info = ticker_obj.info
         except Exception as exc:  # noqa: BLE001
-            raise ServiceError('Failed to fetch stock metrics', str(exc)) from exc
+            raise ServiceError("Failed to fetch stock metrics", str(exc)) from exc
 
         if not info:
-            raise ServiceError('Ticker not found or metrics unavailable', ticker)
+            raise ServiceError("Ticker not found or metrics unavailable", ticker)
 
         response = MetricsResponse(
             ticker=ticker,
-            name=self._safe_info_value(info, 'longName'),
-            exchange=self._safe_info_value(info, 'exchange'),
-            currency=self._safe_info_value(info, 'currency'),
-            price=self._safe_float(info.get('currentPrice')),
-            marketCap=self._safe_float(info.get('marketCap')),
-            trailingPE=self._safe_float(info.get('trailingPE')),
-            forwardPE=self._safe_float(info.get('forwardPE')),
-            dividendYield=self._safe_float(info.get('dividendYield')),
-            fiftyTwoWeekLow=self._safe_float(info.get('fiftyTwoWeekLow')),
-            fiftyTwoWeekHigh=self._safe_float(info.get('fiftyTwoWeekHigh')),
+            name=self._safe_info_value(info, "longName"),
+            exchange=self._safe_info_value(info, "exchange"),
+            currency=self._safe_info_value(info, "currency"),
+            price=self._safe_float(info.get("currentPrice")),
+            marketCap=self._safe_float(info.get("marketCap")),
+            trailingPE=self._safe_float(info.get("trailingPE")),
+            forwardPE=self._safe_float(info.get("forwardPE")),
+            dividendYield=self._safe_float(info.get("dividendYield")),
+            fiftyTwoWeekLow=self._safe_float(info.get("fiftyTwoWeekLow")),
+            fiftyTwoWeekHigh=self._safe_float(info.get("fiftyTwoWeekHigh")),
         )
         self.cache.set(cache_key, response)
         return response

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import cast
 from datetime import date
 
 import pandas as pd
@@ -37,7 +38,7 @@ class StockService:
         cache_key = f"prices:{ticker}:{range_option}"
         cached = self.cache.get(cache_key)
         if cached is not None:
-            return cached
+            return cast(PricesResponse, cached)
 
         period = PERIOD_MAP[range_option]
         try:
@@ -74,7 +75,7 @@ class StockService:
         cache_key = f"metrics:{ticker}"
         cached = self.cache.get(cache_key)
         if cached is not None:
-            return cached
+            return cast(MetricsResponse, cached)
 
         try:
             ticker_obj = self._ticker(ticker)
@@ -110,9 +111,9 @@ class StockService:
 
     @staticmethod
     def _safe_float(value: object) -> float | None:
-        if value is None:
+        if not isinstance(value, int | float | str):
             return None
         try:
             return float(value)
-        except (TypeError, ValueError):
+        except ValueError:
             return None

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import date
 
 import pandas as pd
@@ -19,14 +20,14 @@ PERIOD_MAP: dict[RangeOption, str] = {
 
 
 class ServiceError(Exception):
-    def __init__(self, message: str, details: str | None = None):
+    def __init__(self, message: str, details: str | None = None) -> None:
         super().__init__(message)
         self.message = message
         self.details = details
 
 
 class StockService:
-    def __init__(self, cache_ttl_seconds: int = 60):
+    def __init__(self, cache_ttl_seconds: int = 60) -> None:
         self.cache = TTLCache(ttl_seconds=cache_ttl_seconds)
 
     def _ticker(self, symbol: str) -> yf.Ticker:
@@ -101,7 +102,7 @@ class StockService:
         return response
 
     @staticmethod
-    def _safe_info_value(info: dict, key: str) -> str | None:
+    def _safe_info_value(info: Mapping[str, object], key: str) -> str | None:
         value = info.get(key)
         if value is None:
             return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,3 +20,7 @@ pretty = true
 [[tool.mypy.overrides]]
 module = ["pandas", "yfinance"]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unused_ignores = true
+pretty = true
+
+[[tool.mypy.overrides]]
+module = ["pandas", "yfinance"]
+ignore_missing_imports = true

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ yfinance==0.2.54
 pandas==2.2.3
 pytest==8.3.5
 httpx==0.28.1
+black==24.10.0
+ruff==0.11.0
+mypy==1.15.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import pandas as pd
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 from app.main import app
 
 
 class FakeTicker:
-    def __init__(self, symbol: str):
+    def __init__(self, symbol: str) -> None:
         self.symbol = symbol
         self.info = {
             'currency': 'USD',
@@ -22,12 +23,13 @@ class FakeTicker:
             'fiftyTwoWeekHigh': 200.0,
         }
 
-    def history(self, period: str, interval: str, auto_adjust: bool):
+    def history(self, period: str, interval: str, auto_adjust: bool) -> pd.DataFrame:
+        del period, interval, auto_adjust
         index = pd.to_datetime(['2026-01-01', '2026-01-02'])
         return pd.DataFrame({'Close': [180.1, 181.2]}, index=index)
 
 
-def test_invalid_ticker_returns_400():
+def test_invalid_ticker_returns_400() -> None:
     client = TestClient(app)
     response = client.get('/api/prices', params={'ticker': '$$$', 'range': '1y'})
 
@@ -36,7 +38,7 @@ def test_invalid_ticker_returns_400():
     assert payload['error'] == 'Invalid ticker'
 
 
-def test_prices_response_shape(monkeypatch):
+def test_prices_response_shape(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr('app.service.yf.Ticker', FakeTicker)
     client = TestClient(app)
 
@@ -51,7 +53,7 @@ def test_prices_response_shape(monkeypatch):
     assert payload['points'][0] == {'date': '2026-01-01', 'close': 180.1}
 
 
-def test_metrics_response_shape(monkeypatch):
+def test_metrics_response_shape(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr('app.service.yf.Ticker', FakeTicker)
     client = TestClient(app)
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -11,57 +11,57 @@ class FakeTicker:
     def __init__(self, symbol: str) -> None:
         self.symbol = symbol
         self.info = {
-            'currency': 'USD',
-            'longName': 'Apple Inc.',
-            'exchange': 'NMS',
-            'currentPrice': 189.5,
-            'marketCap': 1_000_000,
-            'trailingPE': 22.1,
-            'forwardPE': 20.0,
-            'dividendYield': 0.004,
-            'fiftyTwoWeekLow': 150.0,
-            'fiftyTwoWeekHigh': 200.0,
+            "currency": "USD",
+            "longName": "Apple Inc.",
+            "exchange": "NMS",
+            "currentPrice": 189.5,
+            "marketCap": 1_000_000,
+            "trailingPE": 22.1,
+            "forwardPE": 20.0,
+            "dividendYield": 0.004,
+            "fiftyTwoWeekLow": 150.0,
+            "fiftyTwoWeekHigh": 200.0,
         }
 
     def history(self, period: str, interval: str, auto_adjust: bool) -> pd.DataFrame:
         del period, interval, auto_adjust
-        index = pd.to_datetime(['2026-01-01', '2026-01-02'])
-        return pd.DataFrame({'Close': [180.1, 181.2]}, index=index)
+        index = pd.to_datetime(["2026-01-01", "2026-01-02"])
+        return pd.DataFrame({"Close": [180.1, 181.2]}, index=index)
 
 
 def test_invalid_ticker_returns_400() -> None:
     client = TestClient(app)
-    response = client.get('/api/prices', params={'ticker': '$$$', 'range': '1y'})
+    response = client.get("/api/prices", params={"ticker": "$$$", "range": "1y"})
 
     assert response.status_code == 400
     payload = response.json()
-    assert payload['error'] == 'Invalid ticker'
+    assert payload["error"] == "Invalid ticker"
 
 
 def test_prices_response_shape(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr('app.service.yf.Ticker', FakeTicker)
+    monkeypatch.setattr("app.service.yf.Ticker", FakeTicker)
     client = TestClient(app)
 
-    response = client.get('/api/prices', params={'ticker': 'AAPL', 'range': '1y'})
+    response = client.get("/api/prices", params={"ticker": "AAPL", "range": "1y"})
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload['ticker'] == 'AAPL'
-    assert payload['range'] == '1y'
-    assert payload['currency'] == 'USD'
-    assert len(payload['points']) == 2
-    assert payload['points'][0] == {'date': '2026-01-01', 'close': 180.1}
+    assert payload["ticker"] == "AAPL"
+    assert payload["range"] == "1y"
+    assert payload["currency"] == "USD"
+    assert len(payload["points"]) == 2
+    assert payload["points"][0] == {"date": "2026-01-01", "close": 180.1}
 
 
 def test_metrics_response_shape(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr('app.service.yf.Ticker', FakeTicker)
+    monkeypatch.setattr("app.service.yf.Ticker", FakeTicker)
     client = TestClient(app)
 
-    response = client.get('/api/metrics', params={'ticker': 'AAPL'})
+    response = client.get("/api/metrics", params={"ticker": "AAPL"})
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload['ticker'] == 'AAPL'
-    assert payload['name'] == 'Apple Inc.'
-    assert payload['marketCap'] == 1_000_000
-    assert payload['dividendYield'] == 0.004
+    assert payload["ticker"] == "AAPL"
+    assert payload["name"] == "Apple Inc."
+    assert payload["marketCap"] == 1_000_000
+    assert payload["dividendYield"] == 0.004

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ]
+}

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -98,10 +98,16 @@ export default function Home() {
         </button>
       </form>
 
-      {error && <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {error && (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
       {loading && <div className="rounded bg-slate-200 p-3 text-sm text-slate-700">Loading...</div>}
 
-      {!loading && !error && prices && <PriceChart points={prices.points} currency={prices.currency} />}
+      {!loading && !error && prices && (
+        <PriceChart points={prices.points} currency={prices.currency} />
+      )}
       {!loading && !error && metrics && <KeyMetrics metrics={metrics} />}
     </main>
   );

--- a/frontend/components/PriceChart.tsx
+++ b/frontend/components/PriceChart.tsx
@@ -39,21 +39,12 @@ export default function PriceChart({ points, currency }: Props) {
           <LineChart data={points} margin={{ top: 10, right: 20, bottom: 10, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#cbd5e1" />
             <XAxis dataKey="date" minTickGap={24} />
-            <YAxis
-              tickFormatter={(value: number) => moneyFormatter(value, currency)}
-              width={90}
-            />
+            <YAxis tickFormatter={(value: number) => moneyFormatter(value, currency)} width={90} />
             <Tooltip
               formatter={(value: number) => moneyFormatter(value, currency)}
               labelFormatter={(label: string) => `Date: ${label}`}
             />
-            <Line
-              type="monotone"
-              dataKey="close"
-              stroke="#2563eb"
-              strokeWidth={2}
-              dot={false}
-            />
+            <Line type="monotone" dataKey="close" stroke="#2563eb" strokeWidth={2} dot={false} />
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,7 +1,6 @@
 import { MetricsResponse, PricesResponse, RangeOption } from './types';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
 
 type ApiError = {
   error?: string;
@@ -24,10 +23,7 @@ async function fetchJson<T>(path: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export async function getPrices(
-  ticker: string,
-  range: RangeOption,
-): Promise<PricesResponse> {
+export async function getPrices(ticker: string, range: RangeOption): Promise<PricesResponse> {
   const query = new URLSearchParams({ ticker, range });
   return fetchJson<PricesResponse>(`/api/prices?${query.toString()}`);
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "next": "15.2.4",
@@ -23,6 +25,16 @@
     "eslint-config-next": "15.2.4",
     "postcss": "8.5.3",
     "tailwindcss": "3.4.17",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "@typescript-eslint/eslint-plugin": "8.26.1",
+    "@typescript-eslint/parser": "8.26.1",
+    "eslint-config-prettier": "10.1.1",
+    "prettier": "3.5.3",
+    "lint-staged": "15.5.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,css,md,json,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,10 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
-  content: [
-    './app/**/*.{js,ts,jsx,tsx,mdx}',
-    './components/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
+  content: ['./app/**/*.{js,ts,jsx,tsx,mdx}', './components/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
### Motivation

- Enforce consistent frontend TypeScript/React/Next linting and Prettier formatting across the repo.  
- Enforce backend Python formatting, import sorting, linting, and basic static typing checks.  
- Provide a reproducible developer workflow for running checks locally and in CI and document contributor guidelines.

### Description

- Add editor/formatting baseline files: `.editorconfig`, `.prettierrc.json`, and `.prettierignore`.  
- Add frontend tooling: `frontend/.eslintrc.json`, update `frontend/package.json` with `format`/`format:check` scripts and `lint-staged` config to run Prettier on staged files.  
- Add backend tooling: `backend/pyproject.toml` (Black, Ruff, MyPy settings) and add `black`, `ruff`, and `mypy` to `backend/requirements.txt`.  
- Add repo-level workflows and docs: root `Makefile` with `format`, `lint`, `typecheck`, `test`, and `check` targets; `.pre-commit-config.yaml` with hooks for Ruff/Black/Prettier/ESLint; `.github/workflows/ci.yml` to run frontend and backend checks on `push`/`pull_request`; and `CONTRIBUTING.md` plus expanded `README.md` development standards.  
- Apply minimal typing/annotation hygiene to backend sources and tests (`backend/app/cache.py`, `backend/app/service.py`, `backend/tests/test_api.py`) so they align with MyPy expectations without changing runtime behavior.

### Testing

- Successfully compiled backend sources with `python -m compileall backend/app backend/tests` to validate basic syntax.  
- Attempted dependency installs and full checks but environment network/proxy restrictions prevented package installs (`cd frontend && npm install` failed with `403`, and `pip install -r backend/requirements.txt` failed with proxy/403).  
- Running `make check` in this environment failed because required Node/Python packages could not be installed; CI workflow and local `make` targets are provided to run full checks in a normal networked environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a20335c3c832da71e1745400d20ad)