### PR TITLE
Add industryType metric from yfinance to backend and frontend

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -22,6 +22,7 @@ class PricesResponse(BaseModel):
 class MetricsResponse(BaseModel):
     ticker: str
     name: str | None = None
+    industryType: str | None = None
     exchange: str | None = None
     currency: str | None = None
     price: float | None = None

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -89,6 +89,8 @@ class StockService:
         response = MetricsResponse(
             ticker=ticker,
             name=self._safe_info_value(info, "longName"),
+            industryType=self._safe_info_value(info, "sector")
+            or self._safe_info_value(info, "industry"),
             exchange=self._safe_info_value(info, "exchange"),
             currency=self._safe_info_value(info, "currency"),
             price=self._safe_float(info.get("currentPrice")),

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -14,6 +14,7 @@ class FakeTicker:
             "currency": "USD",
             "longName": "Apple Inc.",
             "exchange": "NMS",
+            "sector": "Consumer Staples",
             "currentPrice": 189.5,
             "marketCap": 1_000_000,
             "trailingPE": 22.1,
@@ -63,5 +64,6 @@ def test_metrics_response_shape(monkeypatch: MonkeyPatch) -> None:
     payload = response.json()
     assert payload["ticker"] == "AAPL"
     assert payload["name"] == "Apple Inc."
+    assert payload["industryType"] == "Consumer Staples"
     assert payload["marketCap"] == 1_000_000
     assert payload["dividendYield"] == 0.004

--- a/frontend/components/KeyMetrics.tsx
+++ b/frontend/components/KeyMetrics.tsx
@@ -37,6 +37,7 @@ const formatValue = (
 export default function KeyMetrics({ metrics }: Props) {
   const cards = [
     { label: 'Company', value: metrics.name ?? 'N/A' },
+    { label: 'Industry Type', value: metrics.industryType ?? 'N/A' },
     { label: 'Exchange', value: metrics.exchange ?? 'N/A' },
     {
       label: 'Current Price',

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -13,6 +13,7 @@ export type PricesResponse = {
 export type MetricsResponse = {
   ticker: string;
   name: string | null;
+  industryType: string | null;
   exchange: string | null;
   currency: string | null;
   price: number | null;


### PR DESCRIPTION
### Motivation
- Expose company industry/sector information returned by yfinance (e.g., `sector` / `industry`) through the API so the UI can display an "Industry Type" metric.

### Description
- Added `industryType: str | None` to the backend `MetricsResponse` model in `backend/app/models.py`.
- Populated `industryType` in `StockService.get_metrics` by reading `info['sector']` and falling back to `info['industry']` in `backend/app/service.py`.
- Added `industryType: string | null` to the frontend `MetricsResponse` type in `frontend/lib/types.ts` and added an "Industry Type" card to `KeyMetrics` in `frontend/components/KeyMetrics.tsx`.
- Updated the backend API test fixture and assertion in `backend/tests/test_api.py` to assert the new field is returned.

### Testing
- Ran backend tests with `pytest -q` in `backend` and all tests passed (`3 passed`).
- Ran frontend lint with `npm run lint` in `frontend` and it failed in this environment due to a missing `prettier` ESLint configuration dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac1b71a5c832d94c8349a25a9ddb8)