### PR TITLE
fix: change price graph line color to green

### DIFF
--- a/frontend/components/PriceChart.tsx
+++ b/frontend/components/PriceChart.tsx
@@ -44,7 +44,7 @@ export default function PriceChart({ points, currency }: Props) {
               formatter={(value: number) => moneyFormatter(value, currency)}
               labelFormatter={(label: string) => `Date: ${label}`}
             />
-            <Line type="monotone" dataKey="close" stroke="#2563eb" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="close" stroke="#16a34a" strokeWidth={2} dot={false} />
           </LineChart>
         </ResponsiveContainer>
       )}


### PR DESCRIPTION
## Summary
- change the historical close line stroke from blue to green

## Validation
- backend: pytest -q (3 passed)
- frontend: npm run build (build succeeds; ESLint reports missing prettier config in this environment)
- e2e run: frontend and backend processes running; verified GET / on frontend and backend API responses for prices/metrics

Closes #4
