### PR TITLE
feat: add ticker comparison mode in dashboard

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,26 +1,52 @@
 'use client';
 
-import { FormEvent, useEffect, useState } from 'react';
-import PriceChart from '@/components/PriceChart';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import CompareMetrics from '@/components/CompareMetrics';
+import ComparePriceChart from '@/components/ComparePriceChart';
 import KeyMetrics from '@/components/KeyMetrics';
+import PriceChart from '@/components/PriceChart';
 import { getMetrics, getPrices } from '@/lib/api';
 import { MetricsResponse, PricesResponse, RANGE_OPTIONS, RangeOption } from '@/lib/types';
 
 const DEFAULT_TICKER = 'AAPL';
+const MAX_COMPARE_TICKERS = 5;
+
+type CompareResult = {
+  ticker: string;
+  prices: PricesResponse | null;
+  metrics: MetricsResponse | null;
+  error: string | null;
+};
+
+const parseCompareTickers = (input: string): string[] => {
+  const values = input
+    .split(',')
+    .map((value) => value.trim().toUpperCase())
+    .filter(Boolean);
+
+  return Array.from(new Set(values)).slice(0, MAX_COMPARE_TICKERS);
+};
 
 export default function Home() {
   const [tickerInput, setTickerInput] = useState(DEFAULT_TICKER);
   const [ticker, setTicker] = useState(DEFAULT_TICKER);
+  const [compareMode, setCompareMode] = useState(false);
+  const [compareInput, setCompareInput] = useState('AAPL,MSFT');
+  const [compareTickers, setCompareTickers] = useState<string[]>(['AAPL', 'MSFT']);
+  const [normalize, setNormalize] = useState(false);
   const [range, setRange] = useState<RangeOption>('1y');
+
   const [prices, setPrices] = useState<PricesResponse | null>(null);
   const [metrics, setMetrics] = useState<MetricsResponse | null>(null);
+  const [compareResults, setCompareResults] = useState<CompareResult[]>([]);
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
 
-    const loadData = async () => {
+    const loadSingleTicker = async () => {
       setLoading(true);
       setError(null);
       try {
@@ -32,12 +58,14 @@ export default function Home() {
         if (!controller.signal.aborted) {
           setPrices(pricesResult);
           setMetrics(metricsResult);
+          setCompareResults([]);
         }
       } catch (err) {
         if (!controller.signal.aborted) {
           setError(err instanceof Error ? err.message : 'Unexpected error');
           setPrices(null);
           setMetrics(null);
+          setCompareResults([]);
         }
       } finally {
         if (!controller.signal.aborted) {
@@ -46,15 +74,93 @@ export default function Home() {
       }
     };
 
-    void loadData();
+    const loadCompareData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const results = await Promise.all(
+          compareTickers.map(async (item) => {
+            try {
+              const [pricesResult, metricsResult] = await Promise.all([
+                getPrices(item, range),
+                getMetrics(item),
+              ]);
+              return {
+                ticker: item,
+                prices: pricesResult,
+                metrics: metricsResult,
+                error: null,
+              } satisfies CompareResult;
+            } catch (err) {
+              return {
+                ticker: item,
+                prices: null,
+                metrics: null,
+                error: err instanceof Error ? err.message : 'Unexpected error',
+              } satisfies CompareResult;
+            }
+          }),
+        );
+
+        if (!controller.signal.aborted) {
+          setCompareResults(results);
+          setPrices(null);
+          setMetrics(null);
+          if (results.every((result) => result.error)) {
+            setError('Could not load any of the selected tickers.');
+          }
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    if (compareMode) {
+      void loadCompareData();
+    } else {
+      void loadSingleTicker();
+    }
 
     return () => controller.abort();
-  }, [ticker, range]);
+  }, [ticker, range, compareMode, compareTickers]);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (compareMode) {
+      const nextTickers = parseCompareTickers(compareInput);
+      if (nextTickers.length < 2) {
+        setError('Enter at least two tickers for compare mode (comma-separated).');
+        return;
+      }
+      setCompareTickers(nextTickers);
+      return;
+    }
+
     setTicker(tickerInput.toUpperCase());
   };
+
+  const successfulCompareSeries = useMemo(
+    () =>
+      compareResults
+        .filter((result) => result.prices)
+        .map((result) => ({
+          ticker: result.ticker,
+          currency: result.prices?.currency ?? null,
+          points: result.prices?.points ?? [],
+        })),
+    [compareResults],
+  );
+
+  const successfulCompareMetrics = useMemo(
+    () =>
+      compareResults
+        .filter((result) => result.metrics)
+        .map((result) => ({ ticker: result.ticker, metrics: result.metrics as MetricsResponse })),
+    [compareResults],
+  );
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 p-4 sm:p-6">
@@ -62,53 +168,111 @@ export default function Home() {
 
       <form
         onSubmit={onSubmit}
-        className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:flex-row"
+        className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
       >
-        <label className="flex flex-1 flex-col text-sm">
-          <span className="mb-1 font-medium">Ticker</span>
+        <label className="flex items-center gap-2 text-sm font-medium">
           <input
-            className="rounded border border-slate-300 px-3 py-2 uppercase"
-            value={tickerInput}
-            onChange={(event) => setTickerInput(event.target.value)}
-            placeholder="AAPL"
-            maxLength={10}
+            type="checkbox"
+            checked={compareMode}
+            onChange={(event) => {
+              setCompareMode(event.target.checked);
+              setError(null);
+            }}
           />
+          Compare mode
         </label>
 
-        <label className="flex flex-col text-sm">
-          <span className="mb-1 font-medium">Range</span>
-          <select
-            className="rounded border border-slate-300 px-3 py-2"
-            value={range}
-            onChange={(event) => setRange(event.target.value as RangeOption)}
+        {compareMode ? (
+          <label className="flex flex-1 flex-col text-sm">
+            <span className="mb-1 font-medium">Tickers (comma-separated, up to 5)</span>
+            <input
+              className="rounded border border-slate-300 px-3 py-2 uppercase"
+              value={compareInput}
+              onChange={(event) => setCompareInput(event.target.value)}
+              placeholder="AAPL,MSFT,GOOGL"
+              maxLength={60}
+            />
+          </label>
+        ) : (
+          <label className="flex flex-1 flex-col text-sm">
+            <span className="mb-1 font-medium">Ticker</span>
+            <input
+              className="rounded border border-slate-300 px-3 py-2 uppercase"
+              value={tickerInput}
+              onChange={(event) => setTickerInput(event.target.value)}
+              placeholder="AAPL"
+              maxLength={10}
+            />
+          </label>
+        )}
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium">Range</span>
+            <select
+              className="rounded border border-slate-300 px-3 py-2"
+              value={range}
+              onChange={(event) => setRange(event.target.value as RangeOption)}
+            >
+              {RANGE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option.toUpperCase()}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {compareMode && (
+            <label className="flex items-center gap-2 text-sm font-medium sm:pt-7">
+              <input
+                type="checkbox"
+                checked={normalize}
+                onChange={(event) => setNormalize(event.target.checked)}
+              />
+              Normalize to % change from start
+            </label>
+          )}
+
+          <button
+            type="submit"
+            className="self-end rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
           >
-            {RANGE_OPTIONS.map((option) => (
-              <option key={option} value={option}>
-                {option.toUpperCase()}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <button
-          type="submit"
-          className="self-end rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
-        >
-          Load
-        </button>
+            Load
+          </button>
+        </div>
       </form>
 
       {error && (
-        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-          {error}
-        </div>
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>
       )}
       {loading && <div className="rounded bg-slate-200 p-3 text-sm text-slate-700">Loading...</div>}
 
-      {!loading && !error && prices && (
+      {!loading && !compareMode && !error && prices && (
         <PriceChart points={prices.points} currency={prices.currency} />
       )}
-      {!loading && !error && metrics && <KeyMetrics metrics={metrics} />}
+      {!loading && !compareMode && !error && metrics && <KeyMetrics metrics={metrics} />}
+
+      {!loading && compareMode && (
+        <>
+          <ComparePriceChart series={successfulCompareSeries} normalized={normalize} />
+          <CompareMetrics items={successfulCompareMetrics} />
+
+          {compareResults.some((result) => result.error) && (
+            <section className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+              <h2 className="mb-2 font-semibold">Some tickers failed to load</h2>
+              <ul className="list-disc space-y-1 pl-5">
+                {compareResults
+                  .filter((result) => result.error)
+                  .map((result) => (
+                    <li key={result.ticker}>
+                      {result.ticker}: {result.error}
+                    </li>
+                  ))}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
     </main>
   );
 }

--- a/frontend/components/CompareMetrics.tsx
+++ b/frontend/components/CompareMetrics.tsx
@@ -1,0 +1,95 @@
+import { MetricsResponse } from '@/lib/types';
+
+type CompareMetricItem = {
+  ticker: string;
+  metrics: MetricsResponse;
+};
+
+type Props = {
+  items: CompareMetricItem[];
+};
+
+const formatValue = (
+  value: number | null,
+  type: 'currency' | 'number' | 'percent' = 'number',
+  currency?: string | null,
+): string => {
+  if (value === null || Number.isNaN(value)) {
+    return 'N/A';
+  }
+
+  if (type === 'currency') {
+    if (!currency) {
+      return value.toFixed(2);
+    }
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  if (type === 'percent') {
+    return `${(value * 100).toFixed(2)}%`;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    notation: Math.abs(value) >= 1_000_000 ? 'compact' : 'standard',
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const metricRows = [
+  { label: 'Company', get: (m: MetricsResponse) => m.name ?? 'N/A' },
+  { label: 'Industry', get: (m: MetricsResponse) => m.industryType ?? 'N/A' },
+  { label: 'Exchange', get: (m: MetricsResponse) => m.exchange ?? 'N/A' },
+  {
+    label: 'Current Price',
+    get: (m: MetricsResponse) => formatValue(m.price, 'currency', m.currency),
+  },
+  { label: 'Market Cap', get: (m: MetricsResponse) => formatValue(m.marketCap, 'number') },
+  { label: 'Trailing P/E', get: (m: MetricsResponse) => formatValue(m.trailingPE) },
+  { label: 'Forward P/E', get: (m: MetricsResponse) => formatValue(m.forwardPE) },
+  {
+    label: 'Dividend Yield',
+    get: (m: MetricsResponse) => formatValue(m.dividendYield, 'percent'),
+  },
+];
+
+export default function CompareMetrics({ items }: Props) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-lg font-semibold">Compare Metrics</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border-b border-slate-200 px-3 py-2 text-left text-slate-500">Metric</th>
+              {items.map((item) => (
+                <th key={item.ticker} className="border-b border-slate-200 px-3 py-2 text-left">
+                  {item.ticker}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {metricRows.map((row) => (
+              <tr key={row.label}>
+                <td className="border-b border-slate-100 px-3 py-2 font-medium">{row.label}</td>
+                {items.map((item) => (
+                  <td key={`${row.label}-${item.ticker}`} className="border-b border-slate-100 px-3 py-2">
+                    {row.get(item.metrics)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/ComparePriceChart.tsx
+++ b/frontend/components/ComparePriceChart.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { PricePoint } from '@/lib/types';
+
+type CompareSeries = {
+  ticker: string;
+  currency: string | null;
+  points: PricePoint[];
+};
+
+type Props = {
+  series: CompareSeries[];
+  normalized: boolean;
+};
+
+const COLORS = ['#16a34a', '#2563eb', '#9333ea', '#ea580c', '#0f766e'];
+
+const buildChartData = (series: CompareSeries[], normalized: boolean) => {
+  const byDate = new Map<string, Record<string, number | string>>();
+
+  for (const item of series) {
+    if (item.points.length === 0) {
+      continue;
+    }
+
+    const firstClose = item.points[0].close;
+    for (const point of item.points) {
+      const existing = byDate.get(point.date) ?? { date: point.date };
+      const value =
+        normalized && firstClose !== 0 ? ((point.close - firstClose) / firstClose) * 100 : point.close;
+      existing[item.ticker] = Number(value.toFixed(4));
+      byDate.set(point.date, existing);
+    }
+  }
+
+  return Array.from(byDate.values()).sort((a, b) => String(a.date).localeCompare(String(b.date)));
+};
+
+const formatter = (value: number, normalized: boolean) => {
+  if (normalized) {
+    return `${value.toFixed(2)}%`;
+  }
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+export default function ComparePriceChart({ series, normalized }: Props) {
+  const validSeries = series.filter((item) => item.points.length > 0);
+  const data = buildChartData(validSeries, normalized);
+
+  return (
+    <div className="h-80 w-full rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-lg font-semibold">Comparison Chart</h2>
+      {validSeries.length === 0 ? (
+        <p className="text-sm text-slate-500">No comparison data available.</p>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 10, right: 20, bottom: 10, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#cbd5e1" />
+            <XAxis dataKey="date" minTickGap={24} />
+            <YAxis tickFormatter={(value: number) => formatter(value, normalized)} width={90} />
+            <Tooltip formatter={(value: number) => formatter(value, normalized)} />
+            <Legend />
+            {validSeries.map((item, index) => (
+              <Line
+                key={item.ticker}
+                type="monotone"
+                dataKey={item.ticker}
+                stroke={COLORS[index % COLORS.length]}
+                strokeWidth={2}
+                dot={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary\n- add a new compare mode toggle in the dashboard form\n- support loading 2-5 comma-separated tickers and fetching each ticker independently\n- add a multi-series comparison chart with legend and optional normalization (% change from start)\n- add a side-by-side comparison metrics table\n- keep partial results when one ticker fails and show per-ticker error messages\n\n## Validation\n- frontend: npm run build\n- backend: .venv/bin/pytest -q (3 passed)\n\nCloses #8